### PR TITLE
[MCT-1695] Add aria and id to alert

### DIFF
--- a/packages/core/src/components/Alert/Alert.jsx
+++ b/packages/core/src/components/Alert/Alert.jsx
@@ -1,10 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import uniqueId from 'lodash.uniqueid';
 
 export class Alert extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.headingId = this.props.headingId || uniqueId('alert_');
+  }
+
   heading() {
-    if (this.props.heading) {
+    if (typeof id !== 'undefined') {
+      return (
+        <h3 className="ds-c-alert__heading" id={this.props.ariaLabelledBy}>
+          {this.props.heading}
+        </h3>
+      );
+    } else {
       return <h3 className="ds-c-alert__heading">{this.props.heading}</h3>;
     }
   }
@@ -18,7 +31,11 @@ export class Alert extends React.PureComponent {
     );
 
     return (
-      <div className={classes} role={this.props.role}>
+      <div
+        className={classes}
+        role={this.props.role}
+        aria-labelledby={this.props.ariaLabelledBy}
+      >
         <div className="ds-c-alert__body">
           {this.heading()}
           {this.props.children}
@@ -29,11 +46,12 @@ export class Alert extends React.PureComponent {
 }
 
 Alert.propTypes = {
+  ariaLabelledBy: PropTypes.string,
   children: PropTypes.node.isRequired,
   heading: PropTypes.string,
   hideIcon: PropTypes.bool,
   /** ARIA `role` */
-  role: PropTypes.oneOf(['alert', 'alertdialog']),
+  role: PropTypes.oneOf(['alert', 'alertdialog', 'region']),
   variation: PropTypes.oneOf(['error', 'warn', 'success'])
 };
 


### PR DESCRIPTION


### Added
List new features or components. Include a screenshot for new visual elements.
- added `aria-labelledby` to the outer `div` of the Alert. Also, added this to the options
- added the option of `region` to `role`
- added a default `id` with the ability to write a custom `id`

